### PR TITLE
Make it possible to customize a custom usergrid properties file with env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,14 @@ ENV TOMCAT_CONFIGURATION_FLAG /usergrid/.tomcat_admin_created
 RUN mkdir /usergrid
 WORKDIR /usergrid
 
-RUN apt-get update ; apt-get install -y wget pwgen openjdk-7-jdk tomcat7
+RUN apt-get update ; apt-get install -y wget curl pwgen openjdk-7-jdk tomcat7
 
 #
 # Configure basic stuff, nothing important.
 #
 ADD create_tomcat_admin_user.sh /usergrid/create_tomcat_admin_user.sh
 ADD run.sh /usergrid/run.sh
+ADD usergrid-custom.properties /usr/share/tomcat7/lib/usergrid-custom.properties
 RUN chmod +x /usergrid/*.sh
 RUN ln -s /etc/tomcat7/ /usr/share/tomcat7/conf
  
@@ -39,9 +40,11 @@ ADD ROOT.war /usr/share/tomcat7/webapps/ROOT.war
 
 RUN ln -s /usr/share/tomcat7/webapps/ /etc/tomcat7/webapps
 
+RUN curl -sLo /usr/local/bin/ep https://github.com/kreuzwerker/envplate/releases/download/v0.0.5/ep-linux && chmod +x /usr/local/bin/ep
+
 #
 # Port to expose (default for tomcat: 8080)
 #
 EXPOSE 8080
 
-ENTRYPOINT ./run.sh
+ENTRYPOINT ["/usr/local/bin/ep", "/usr/share/tomcat7/lib/usergrid-custom.properties", "--", "./run.sh"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ In this case, `rGlsLYtiPce2` is the password allocated to the `admin` user for T
 
 **Important**: default username and password for usergrid_ is `superuser` and `VDprvB6bt7ebDW`. This can be changed by customising Dockerfile to suit Your needs and add custom `usergrid-*.properties` file. **Without modifications this should not be used on production.**
 
+**New**: You can now set certain properties using ENV vars. I.e. --env SYSADMIN_PASSWORD=mypassword.
+
+	docker run -d -p 8080:8080 --env SYSADMIN_PASSWORD=mypassword --link cass1:cassandra gaborwnuk/usergrid
+
+For the full list of ENV vars see usergrid-custom.properties. See the [envplate](https://github.com/kreuzwerker/envplate) library for more details on syntax
+and variable replacement rules.
+
 You can now check usergrid_ status with:
 
 	curl http://127.0.0.1:8080/status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+
+cassandra:
+  image: poklet/cassandra
+  ports:
+   - "9042:9042"
+   - "9160:9160"
+   - "7199:7199"
+usergrid:
+  environment:
+   SYSADMIN_EMAIL: cswanberg@mad-swan.com
+   SYSADMIN_PASSWORD: password
+  build: .
+  links:
+   - cassandra
+  ports:
+   - "8080:8080"
+usergridportal:
+  image: sumanyu/usergrid-portal
+  ports:
+   - "3000:3000"
+opscenter:
+  image: poklet/opscenter
+  ports:
+   - "8888:8888"

--- a/usergrid-custom.properties
+++ b/usergrid-custom.properties
@@ -1,0 +1,43 @@
+cassandra.username=${CASSANDRA_USERNAME:- }
+cassandra.password=${CASSANDRA_PASSWORD:- }
+# SysAdmin login
+usergrid.sysadmin.login.name=${SYSADMIN_USERNAME:-superuser}
+usergrid.sysadmin.login.email=${SYSADMIN_EMAIL:-superuser@localhost}
+usergrid.sysadmin.login.password=${SYSADMIN_PASSWORD:-VDprvB6bt7ebDW}
+usergrid.sysadmin.email=${SYSADMIN_EMAIL:-superuser@localhost}
+usergrid.sysadmin.login.allowed=true
+
+usergrid.sysadmin.approve.users=false
+usergrid.sysadmin.approve.organizations=false
+
+AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:- }
+AWS_SECRET_KEY=${AWS_SECRET_KEY:- }
+usergrid.binary.bucketname=${BUCKET_NAME:-usergrid-test}
+
+usergrid.test.sample_data_url=
+
+# Disable Mongo API Server
+usergrid.mongo.disable=true
+
+# Disable WebSocket Server
+usergrid.websocket.disable=true
+
+
+mail.transport.protocol=${MAIL_PROTOCOL:-smtps}
+mail.smtps.host=${SMTPS_HOST:- }
+mail.smtps.port=${SMTPS_PORT:- }
+mail.smtps.auth=${SMTPS_AUTH:-true}
+mail.smtps.quitwait=${SMTPS_QUITWAIT:-false}
+mail.smtps.username=${SMTPS_USERNAME:- }
+mail.smtps.password=${SMTPS_PASSWORD:- }
+
+usergrid.recaptcha.public=${RECAPTCHA_PUBLIC:- }
+usergrid.recaptcha.private=${RECAPTCHA_PRIVATE:- }
+
+usergrid.management.admin_users_require_confirmation=false
+usergrid.management.admin_users_require_activation=false
+usergrid.management.notify_admin_of_activation=false
+usergrid.management.organizations_require_confirmation=false
+usergrid.management.organizations_require_activation=false
+usergrid.management.notify_sysadmin_of_new_organizations=true
+usergrid.management.notify_sysadmin_of_new_admin_users=true


### PR DESCRIPTION
What are your thoughts on adding something like this? I made use of this little utility, https://github.com/kreuzwerker/envplate. I exposed a few of the settings that I envisioned being useful in the
short term. I think ultimately one would want to fork this to customize workflow and email copy, etc, but even still, the sensitive bits like passwords would be best in ENV vars. If you can merge it in, then we can avoid having too many forks out on docker hub.